### PR TITLE
添加gradle脚本集成greendao教程

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Welcome `Star` and `Fork`, your support is my greatest affirmation.
 1. [ORM 框架之 greenDAO 使用心得](http://itangqi.me/2015/07/26/orm-greendao-summary/)
 2. [SQLite数据库框架ORMLite与GreenDao的简单比较](http://blog.csdn.net/xushuaic/article/details/24434881)
 3. [在AndoridStudio中引入GreenDAO](http://blog.csdn.net/h3c4lenovo/article/details/43566169)
+4. [gradle脚本集成greendao-generator生成android端greendao](http://www.chenkaihua.com/2016/01/05/gradle-integration-greendao_generator-generate-greendao)
 
 ### GridView
 


### PR DESCRIPTION
添加gradle脚本集成greendao教程,集成greendao不需要新建java module
